### PR TITLE
Add full Folia and Canvas 26.1.2+ scheduler support

### DIFF
--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/SvgCore.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/SvgCore.java
@@ -12,6 +12,7 @@ import io.github.theodoremeyer.simplevoicegeyser.core.geyser.GeyserEventHook;
 import io.github.theodoremeyer.simplevoicegeyser.core.geyser.GeyserHook;
 import io.github.theodoremeyer.simplevoicegeyser.core.managers.GroupManager;
 import io.github.theodoremeyer.simplevoicegeyser.core.managers.PlayerManager;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
 import io.github.theodoremeyer.simplevoicegeyser.core.server.JettyServer;
 import io.github.theodoremeyer.simplevoicegeyser.core.server.connection.ConnectionManager;
 import io.github.theodoremeyer.simplevoicegeyser.core.svc.VoiceChatBridge;
@@ -157,6 +158,7 @@ public final class SvgCore {
         }
 
         state = State.SHUTDOWN;
+        connectionManager.rejectNewConnections();
         connectionManager.disconnectAll();
 
         try {
@@ -171,6 +173,13 @@ public final class SvgCore {
 
         AudioThread.shutdown();
 
+        try {
+            platform.getTaskScheduler().shutdown();
+        } catch (Exception e) {
+            getLogger().severe("Failed to shut down task scheduler: " + e.getMessage());
+            getLogger().debug("Task scheduler shutdown failed", e);
+        }
+
         if (playerVcPswd != null) {
             playerVcPswd.shutdown();
         }
@@ -179,6 +188,21 @@ public final class SvgCore {
         jettyServer = null;
         groupManager = null;
         command = null;
+    }
+
+    /**
+     * @return whether the core is fully running and accepting work
+     */
+    public static boolean isRunning() {
+        SvgCore core = getInstance();
+        return core != null && core.state == State.RUNNING;
+    }
+
+    /**
+     * @return platform task scheduler
+     */
+    public static TaskScheduler getTaskScheduler() {
+        return getInstance().platform.getTaskScheduler();
     }
 
     /**

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/api/Platform.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/api/Platform.java
@@ -3,6 +3,7 @@ package io.github.theodoremeyer.simplevoicegeyser.core.api;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.chat.SvgLogger;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.data.DataType;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.data.SvgFile;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
 import io.github.theodoremeyer.simplevoicegeyser.core.svc.VoiceChatBridge;
 
 import java.io.File;
@@ -67,5 +68,11 @@ public interface Platform {
      */
     boolean isDependencyEnabled(String name);
 
+    /**
+     * Platform task scheduler used for global/region/entity/async work.
+     *
+     * @return task scheduler owned by this platform instance
+     */
+    TaskScheduler getTaskScheduler();
 
 }

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/api/sender/SvgPlayer.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/api/sender/SvgPlayer.java
@@ -44,4 +44,15 @@ public abstract class SvgPlayer extends Sender {
      * @return the Player
      */
     public abstract Object getPlayer();
+
+    /**
+     * Cached look yaw in degrees for spatial audio and other off-thread readers.
+     * <p>
+     * Platforms that cannot expose a thread-safe yaw return {@code null}.
+     *
+     * @return yaw degrees, or {@code null} when unavailable
+     */
+    public Double getLookYawDegrees() {
+        return null;
+    }
 }

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/audio/AudioThread.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/audio/AudioThread.java
@@ -1,7 +1,10 @@
 package io.github.theodoremeyer.simplevoicegeyser.core.audio;
 
+import io.github.theodoremeyer.simplevoicegeyser.core.SvgCore;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Server's Audio Thread
@@ -11,6 +14,7 @@ public final class AudioThread {
     private static AudioThread instance;
 
     private final ExecutorService executor;
+    private final AtomicBoolean accepting = new AtomicBoolean(true);
 
     /**
      * EntryPoint
@@ -28,7 +32,20 @@ public final class AudioThread {
      * Stop Thread
      */
     public static void shutdown() {
-        instance.executor.shutdownNow();
+        AudioThread current = instance;
+        if (current == null) {
+            return;
+        }
+        current.accepting.set(false);
+        current.executor.shutdownNow();
+    }
+
+    /**
+     * @return whether new audio work is accepted
+     */
+    public static boolean isAccepting() {
+        AudioThread current = instance;
+        return current != null && current.accepting.get();
     }
 
     /**
@@ -44,6 +61,23 @@ public final class AudioThread {
      * @param runnable code to execute
      */
     public static void execute(Runnable runnable) {
-        instance.getExecutor().execute(runnable);
+        AudioThread current = instance;
+        if (current == null || !current.accepting.get() || runnable == null) {
+            return;
+        }
+        try {
+            current.executor.execute(() -> {
+                try {
+                    runnable.run();
+                } catch (Throwable t) {
+                    try {
+                        SvgCore.getLogger().error("SVG-Audio task failed", t);
+                    } catch (Exception ignored) {
+                    }
+                }
+            });
+        } catch (RuntimeException ex) {
+            // Executor may already be shut down.
+        }
     }
 }

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/audio/SvgAudioListener.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/audio/SvgAudioListener.java
@@ -466,6 +466,17 @@ public final class SvgAudioListener {
     }
 
     private Double resolveReceiverYaw(VoicechatConnection receiverConnection) {
+        // Prefer the platform player's thread-safe yaw snapshot. Reading Bukkit
+        // Player#getLocation from the SVG-Audio thread is unsafe on Folia/Canvas.
+        io.github.theodoremeyer.simplevoicegeyser.core.api.sender.SvgPlayer svgPlayer =
+                SvgCore.getPlayerManager().getPlayer(listenerId);
+        if (svgPlayer != null) {
+            Double cachedYaw = svgPlayer.getLookYawDegrees();
+            if (cachedYaw != null) {
+                return cachedYaw;
+            }
+        }
+
         if (receiverConnection == null || receiverConnection.getPlayer() == null) {
             return null;
         }
@@ -474,18 +485,7 @@ public final class SvgAudioListener {
             return null;
         }
 
-        try {
-            Method getLocation = platformPlayer.getClass().getMethod("getLocation");
-            Object location = getLocation.invoke(platformPlayer);
-            if (location != null) {
-                Double yaw = invokeNumericNoArgs(location, "getYaw");
-                if (yaw != null) {
-                    return yaw;
-                }
-            }
-        } catch (Exception ignored) {
-        }
-
+        // Fabric (and other non-Bukkit) platforms expose yaw without a Bukkit location.
         Double yaw = invokeNumericNoArgs(platformPlayer, "getYRot");
         if (yaw != null) {
             return yaw;

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/managers/PlayerManager.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/managers/PlayerManager.java
@@ -67,8 +67,19 @@ public final class PlayerManager {
      * @param player the player to add
      */
     public void addPlayer(SvgPlayer player) {
-        players.put(player.getUniqueId(), player);
-        playersByName.put(player.getName(), player);
+        UUID uuid = player.getUniqueId();
+        String name = player.getName();
+
+        // Replace any stale mapping for this UUID/name as one compound transition.
+        SvgPlayer previousById = players.put(uuid, player);
+        if (previousById != null && !previousById.getName().equals(name)) {
+            playersByName.remove(previousById.getName(), previousById);
+        }
+
+        SvgPlayer previousByName = playersByName.put(name, player);
+        if (previousByName != null && !previousByName.getUniqueId().equals(uuid)) {
+            players.remove(previousByName.getUniqueId(), previousByName);
+        }
     }
 
     /**
@@ -77,15 +88,18 @@ public final class PlayerManager {
      * @param player the player to remove
      */
     public void removePlayer(SvgPlayer player) {
+        UUID uuid = player.getUniqueId();
+        String name = player.getName();
+
+        // Only remove if this exact instance is still mapped (session replacement safe).
+        players.remove(uuid, player);
+        playersByName.remove(name, player);
+
         SvgCore.getConnectionManager().disconnect(
-                player.getUniqueId(),
+                uuid,
                 ConnectionStates.DisconnectCodes.PLAYER_LEAVE.getCode(),
                 "Player left the game."
         );
-        //SvgCore.getWsManager().playerLeave(player);
-
-        players.remove(player.getUniqueId());
-        playersByName.remove(player.getName());
     }
 
     // Is Player Online

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/CancelledTask.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/CancelledTask.java
@@ -1,0 +1,24 @@
+package io.github.theodoremeyer.simplevoicegeyser.core.schedule;
+
+/**
+ * Task handle that is already cancelled and ignores further cancel requests.
+ */
+public final class CancelledTask implements ScheduledTask {
+
+    /**
+     * Shared cancelled handle.
+     */
+    public static final CancelledTask INSTANCE = new CancelledTask();
+
+    private CancelledTask() {}
+
+    @Override
+    public void cancel() {
+        // already cancelled
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return true;
+    }
+}

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/DirectTaskScheduler.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/DirectTaskScheduler.java
@@ -1,0 +1,241 @@
+package io.github.theodoremeyer.simplevoicegeyser.core.schedule;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+/**
+ * Non-region scheduler used by Fabric and unit tests.
+ * <p>
+ * Global/entity tasks run on the calling thread (or a dedicated sync executor when
+ * configured). Async tasks use a scheduler-owned executor. This preserves the
+ * previous Fabric behavior of invoking player APIs directly from the caller.
+ */
+public final class DirectTaskScheduler implements TaskScheduler {
+
+    private final AtomicBoolean accepting = new AtomicBoolean(true);
+    private final Set<ScheduledTask> tracked = ConcurrentHashMap.newKeySet();
+    private final ScheduledExecutorService asyncExecutor;
+    private final Predicate<UUID> entityPresent;
+    private final boolean ownsAsyncExecutor;
+
+    /**
+     * Create a scheduler with default async executor and all entities considered present.
+     */
+    public DirectTaskScheduler() {
+        this(uuid -> true, Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "SVG-DirectScheduler");
+            t.setDaemon(true);
+            return t;
+        }), true);
+    }
+
+    /**
+     * @param entityPresent returns whether an entity id can currently accept work
+     * @param asyncExecutor executor for async tasks
+     * @param ownsAsyncExecutor whether {@link #shutdown()} should terminate the executor
+     */
+    public DirectTaskScheduler(
+            Predicate<UUID> entityPresent,
+            ScheduledExecutorService asyncExecutor,
+            boolean ownsAsyncExecutor
+    ) {
+        this.entityPresent = entityPresent == null ? uuid -> true : entityPresent;
+        this.asyncExecutor = asyncExecutor;
+        this.ownsAsyncExecutor = ownsAsyncExecutor;
+    }
+
+    @Override
+    public boolean isAcceptingTasks() {
+        return accepting.get();
+    }
+
+    @Override
+    public boolean isRegionThreaded() {
+        return false;
+    }
+
+    @Override
+    public void shutdown() {
+        if (!accepting.compareAndSet(true, false)) {
+            cancelAll();
+            return;
+        }
+        cancelAll();
+        if (ownsAsyncExecutor) {
+            asyncExecutor.shutdownNow();
+        }
+    }
+
+    @Override
+    public void cancelAll() {
+        for (ScheduledTask task : tracked) {
+            task.cancel();
+        }
+        tracked.clear();
+    }
+
+    @Override
+    public ScheduledTask runGlobal(String taskName, Runnable task) {
+        return runNow(taskName, task);
+    }
+
+    @Override
+    public ScheduledTask runGlobalLater(String taskName, Runnable task, long delayTicks) {
+        long delayMs = Math.max(0L, delayTicks) * 50L;
+        return runAsyncLater(taskName, task, delayMs, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public ScheduledTask runGlobalTimer(String taskName, Runnable task, long delayTicks, long periodTicks) {
+        long delayMs = Math.max(0L, delayTicks) * 50L;
+        long periodMs = Math.max(1L, periodTicks) * 50L;
+        return runAsyncTimer(taskName, task, delayMs, periodMs, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public ScheduledTask runAtLocation(
+            String taskName,
+            String worldName,
+            int blockX,
+            int blockY,
+            int blockZ,
+            Runnable task
+    ) {
+        return runNow(taskName, task);
+    }
+
+    @Override
+    public ScheduledTask runForEntity(String taskName, UUID entityId, Runnable task, Runnable retired) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        if (entityId == null || !entityPresent.test(entityId)) {
+            runRetired(retired);
+            return CancelledTask.INSTANCE;
+        }
+        return runNow(taskName, task);
+    }
+
+    @Override
+    public ScheduledTask runForEntityLater(
+            String taskName,
+            UUID entityId,
+            Runnable task,
+            Runnable retired,
+            long delayTicks
+    ) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        if (entityId == null || !entityPresent.test(entityId)) {
+            runRetired(retired);
+            return CancelledTask.INSTANCE;
+        }
+        return runGlobalLater(taskName, () -> {
+            if (!entityPresent.test(entityId)) {
+                runRetired(retired);
+                return;
+            }
+            new NamedTask(taskName, task).run();
+        }, delayTicks);
+    }
+
+    @Override
+    public void executeForEntity(String taskName, UUID entityId, Runnable task, Runnable retired) {
+        runForEntity(taskName, entityId, task, retired);
+    }
+
+    @Override
+    public ScheduledTask runAsync(String taskName, Runnable task) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        NamedTask named = new NamedTask(taskName, task);
+        Future<?> future = asyncExecutor.submit(named);
+        return track(new FutureTask(future));
+    }
+
+    @Override
+    public ScheduledTask runAsyncLater(String taskName, Runnable task, long delay, TimeUnit unit) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        NamedTask named = new NamedTask(taskName, task);
+        ScheduledFuture<?> future = asyncExecutor.schedule(named, delay, unit);
+        return track(new FutureTask(future));
+    }
+
+    @Override
+    public ScheduledTask runAsyncTimer(
+            String taskName,
+            Runnable task,
+            long delay,
+            long period,
+            TimeUnit unit
+    ) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        NamedTask named = new NamedTask(taskName, task);
+        ScheduledFuture<?> future = asyncExecutor.scheduleAtFixedRate(named, delay, period, unit);
+        return track(new FutureTask(future));
+    }
+
+    private ScheduledTask runNow(String taskName, Runnable task) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        SimpleScheduledTask handle = new SimpleScheduledTask();
+        tracked.add(handle);
+        if (!handle.isCancelled()) {
+            new NamedTask(taskName, task).run();
+        }
+        tracked.remove(handle);
+        return handle;
+    }
+
+    private ScheduledTask track(ScheduledTask task) {
+        tracked.add(task);
+        return task;
+    }
+
+    private void runRetired(Runnable retired) {
+        if (retired == null) {
+            return;
+        }
+        try {
+            retired.run();
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private final class FutureTask implements ScheduledTask {
+        private final Future<?> future;
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        private FutureTask(Future<?> future) {
+            this.future = future;
+        }
+
+        @Override
+        public void cancel() {
+            if (cancelled.compareAndSet(false, true)) {
+                future.cancel(false);
+                tracked.remove(this);
+            }
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled.get() || future.isCancelled();
+        }
+    }
+}

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/NamedTask.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/NamedTask.java
@@ -1,0 +1,46 @@
+package io.github.theodoremeyer.simplevoicegeyser.core.schedule;
+
+import io.github.theodoremeyer.simplevoicegeyser.core.SvgCore;
+
+/**
+ * Runnable wrapper that carries a stable task path for profilers and logs.
+ */
+public final class NamedTask implements Runnable {
+
+    private final String name;
+    private final Runnable delegate;
+
+    /**
+     * @param name stable logical task path (for example {@code svg/player/send-message})
+     * @param delegate work to execute
+     */
+    public NamedTask(String name, Runnable delegate) {
+        this.name = name == null || name.isBlank() ? "svg/unnamed" : name;
+        this.delegate = delegate;
+    }
+
+    /**
+     * @return stable task path
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void run() {
+        try {
+            delegate.run();
+        } catch (Throwable t) {
+            try {
+                SvgCore.getLogger().error("Scheduled task failed: " + name, t);
+            } catch (Exception ignored) {
+                // Logger may be unavailable during early shutdown.
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/ScheduledTask.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/ScheduledTask.java
@@ -1,0 +1,17 @@
+package io.github.theodoremeyer.simplevoicegeyser.core.schedule;
+
+/**
+ * Handle for a task scheduled through {@link TaskScheduler}.
+ */
+public interface ScheduledTask {
+
+    /**
+     * Cancel this task if it has not already finished.
+     */
+    void cancel();
+
+    /**
+     * @return whether this task has been cancelled
+     */
+    boolean isCancelled();
+}

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/SimpleScheduledTask.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/SimpleScheduledTask.java
@@ -1,0 +1,39 @@
+package io.github.theodoremeyer.simplevoicegeyser.core.schedule;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/**
+ * Basic cancellable task handle with an optional cancel callback.
+ */
+public final class SimpleScheduledTask implements ScheduledTask {
+
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+    private final Consumer<SimpleScheduledTask> onCancel;
+
+    /**
+     * @param onCancel optional cancel callback
+     */
+    public SimpleScheduledTask(Consumer<SimpleScheduledTask> onCancel) {
+        this.onCancel = onCancel;
+    }
+
+    /**
+     * Create a handle with no cancel side effects.
+     */
+    public SimpleScheduledTask() {
+        this(null);
+    }
+
+    @Override
+    public void cancel() {
+        if (cancelled.compareAndSet(false, true) && onCancel != null) {
+            onCancel.accept(this);
+        }
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled.get();
+    }
+}

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/TaskScheduler.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/TaskScheduler.java
@@ -1,0 +1,108 @@
+package io.github.theodoremeyer.simplevoicegeyser.core.schedule;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Platform scheduling abstraction for global, region, entity, and async work.
+ * <p>
+ * Implementations must attribute work to this plugin and reject new tasks after
+ * {@link #shutdown()}.
+ */
+public interface TaskScheduler {
+
+    /**
+     * @return whether this scheduler accepts new work
+     */
+    boolean isAcceptingTasks();
+
+    /**
+     * @return whether the platform uses regionized threading (Folia/Canvas)
+     */
+    boolean isRegionThreaded();
+
+    /**
+     * Reject new work and cancel tracked tasks owned by this scheduler.
+     * Idempotent.
+     */
+    void shutdown();
+
+    /**
+     * Cancel all tracked tasks without fully shutting down acceptance state.
+     * Prefer {@link #shutdown()} during plugin disable.
+     */
+    void cancelAll();
+
+    /**
+     * Run on the global region / global server tick context.
+     * Only for work that does not touch region-owned world or entity state.
+     */
+    ScheduledTask runGlobal(String taskName, Runnable task);
+
+    /**
+     * Delayed global work.
+     * @param delayTicks delay in server ticks
+     */
+    ScheduledTask runGlobalLater(String taskName, Runnable task, long delayTicks);
+
+    /**
+     * Repeating global work.
+     */
+    ScheduledTask runGlobalTimer(String taskName, Runnable task, long delayTicks, long periodTicks);
+
+    /**
+     * Run on the region that owns the given world location.
+     * @param worldName world name
+     * @param blockX block X
+     * @param blockY block Y
+     * @param blockZ block Z
+     */
+    ScheduledTask runAtLocation(
+            String taskName,
+            String worldName,
+            int blockX,
+            int blockY,
+            int blockZ,
+            Runnable task
+    );
+
+    /**
+     * Run on the scheduler that owns the given player/entity.
+     * @param entityId player/entity UUID
+     * @param retired invoked if the entity retires before or while scheduling
+     */
+    ScheduledTask runForEntity(String taskName, UUID entityId, Runnable task, Runnable retired);
+
+    /**
+     * Delayed entity-owned work.
+     * @param delayTicks delay in server ticks
+     */
+    ScheduledTask runForEntityLater(
+            String taskName,
+            UUID entityId,
+            Runnable task,
+            Runnable retired,
+            long delayTicks
+    );
+
+    /**
+     * Execute entity-owned work immediately when already on the owning region,
+     * otherwise schedule it. Never runs entity work on an unrelated thread.
+     */
+    void executeForEntity(String taskName, UUID entityId, Runnable task, Runnable retired);
+
+    /**
+     * Asynchronous work that must not touch Bukkit region/entity state.
+     */
+    ScheduledTask runAsync(String taskName, Runnable task);
+
+    /**
+     * Delayed asynchronous work.
+     */
+    ScheduledTask runAsyncLater(String taskName, Runnable task, long delay, TimeUnit unit);
+
+    /**
+     * Repeating asynchronous work.
+     */
+    ScheduledTask runAsyncTimer(String taskName, Runnable task, long delay, long period, TimeUnit unit);
+}

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/server/connection/ConnectionManager.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/server/connection/ConnectionManager.java
@@ -6,9 +6,12 @@ import io.github.theodoremeyer.simplevoicegeyser.core.audio.AudioSessionNegotiat
 import io.github.theodoremeyer.simplevoicegeyser.core.server.connection.compatibility.ClientIdentity;
 import org.eclipse.jetty.websocket.api.Session;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * The authoritative manager for all active websocket/voice connections.
@@ -19,10 +22,26 @@ public final class ConnectionManager {
     private final Map<UUID, SvgConnection> connections =
             new ConcurrentHashMap<>();
 
+    private final AtomicBoolean accepting = new AtomicBoolean(true);
+
     /**
      * No arg Constructor
      */
     public ConnectionManager() {}
+
+    /**
+     * Reject new connections. Idempotent.
+     */
+    public void rejectNewConnections() {
+        accepting.set(false);
+    }
+
+    /**
+     * @return whether this manager is still accepting new connections
+     */
+    public boolean isAcceptingConnections() {
+        return accepting.get();
+    }
 
     /**
      * Connect a Session, and hold Identity and AudioSessionNegotiation for the player.
@@ -39,11 +58,17 @@ public final class ConnectionManager {
             ClientIdentity clientIdentity
     ) {
 
-        SvgConnection oldConnection = connections.remove(player.getUniqueId());
+        if (!accepting.get()) {
+            throw new IllegalStateException("ConnectionManager is not accepting connections");
+        }
 
-        if (oldConnection != null) {
+        UUID uuid = player.getUniqueId();
+        SvgConnection connection = new SvgConnection(session, player, audioNegotiation, clientIdentity);
+
+        SvgConnection oldConnection = connections.put(uuid, connection);
+        if (oldConnection != null && oldConnection != connection) {
             SvgCore.getLogger().debug(
-                    "ConnectionManager: Replacing existing connection for: " + player.getUniqueId()
+                    "ConnectionManager: Replacing existing connection for: " + uuid
             );
 
             oldConnection.disconnect(
@@ -52,11 +77,8 @@ public final class ConnectionManager {
             );
         }
 
-        SvgConnection connection = new SvgConnection(session, player, audioNegotiation, clientIdentity);
-        connections.put(player.getUniqueId(), connection);
-
         SvgCore.getLogger().info(
-                "[ConnectionManager] Connected: " + player.getName() + " (" + player.getUniqueId() + ")"
+                "[ConnectionManager] Connected: " + player.getName() + " (" + uuid + ")"
         );
 
         return connection;
@@ -108,11 +130,22 @@ public final class ConnectionManager {
      * Disconnect all Connections
      */
     public void disconnectAll() {
-        for (SvgConnection connection : connections.values()) {
-            connection.disconnect(1001, "Server shutting down");
+        rejectNewConnections();
+
+        List<SvgConnection> snapshot = new ArrayList<>(connections.values());
+        connections.clear();
+
+        for (SvgConnection connection : snapshot) {
+            try {
+                connection.disconnect(1001, "Server shutting down");
+            } catch (Exception e) {
+                SvgCore.getLogger().debug(
+                        "ConnectionManager: Error while disconnecting " + connection.getUuid(),
+                        e
+                );
+            }
         }
 
-        connections.clear();
         SvgCore.getLogger().info("[ConnectionManager] Disconnected all clients");
     }
 }

--- a/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/server/packets/JoinPacket.java
+++ b/core/src/main/java/io/github/theodoremeyer/simplevoicegeyser/core/server/packets/JoinPacket.java
@@ -3,6 +3,7 @@ package io.github.theodoremeyer.simplevoicegeyser.core.server.packets;
 import de.maxhenkel.voicechat.api.Group;
 import de.maxhenkel.voicechat.api.VoicechatConnection;
 import io.github.theodoremeyer.simplevoicegeyser.core.SvgCore;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.sender.SvgPlayer;
 import io.github.theodoremeyer.simplevoicegeyser.core.server.connection.ConnectionStates;
 import io.github.theodoremeyer.simplevoicegeyser.core.server.connection.SvgConnection;
 import io.github.theodoremeyer.simplevoicegeyser.core.server.connection.auth.AuthException;
@@ -65,6 +66,15 @@ public final class JoinPacket implements Packet {
             return;
         }
 
+        if (!SvgCore.isRunning() || !SvgCore.getConnectionManager().isAcceptingConnections()) {
+            socket.sendRaw(
+                    ConnectionStates.MessageType.ERROR,
+                    "Server is shutting down.",
+                    false
+            );
+            return;
+        }
+
         String username = json.optString("username", "").trim();
         String password = json.optString("password", "");
 
@@ -80,9 +90,30 @@ public final class JoinPacket implements Packet {
             return;
         }
 
+        // Re-validate the in-game session after auth; browser/Jetty threads must not
+        // assume the SvgPlayer snapshot is still the online session.
+        SvgPlayer onlinePlayer = SvgCore.getPlayerManager().getPlayer(response.uuid());
+        if (onlinePlayer == null || !onlinePlayer.isOnline()) {
+            socket.sendRaw(
+                    ConnectionStates.MessageType.ERROR,
+                    "Authentication failed: Timeout: You didn’t join the server in time.",
+                    false
+            );
+            return;
+        }
+
+        if (!SvgCore.isRunning() || !SvgCore.getConnectionManager().isAcceptingConnections()) {
+            socket.sendRaw(
+                    ConnectionStates.MessageType.ERROR,
+                    "Server is shutting down.",
+                    false
+            );
+            return;
+        }
+
         SvgConnection connection = SvgCore.getConnectionManager().connect(
                 socket.getSession(),
-                response.player(),
+                onlinePlayer,
                 socket.getAudioNegotiation(),
                 clientIdentity
         );
@@ -118,7 +149,7 @@ public final class JoinPacket implements Packet {
 
             if (!alreadyInGroup || forceDefaultGroup) {
                 SvgCore.getGroupManager().createGroup(
-                        response.player(),
+                        onlinePlayer,
                         "Svg",
                         SvgCore.getConfig().DEFAULT_GROUP_PASSWORD.get(),
                         Group.Type.OPEN,
@@ -134,7 +165,7 @@ public final class JoinPacket implements Packet {
             }
         }
 
-        response.player().sendMessage(SvgCore.getPrefix() + "Connected!");
+        onlinePlayer.sendMessage(SvgCore.getPrefix() + "Connected!");
 
         connection.sendMessage(
                 ConnectionStates.MessageType.STATUS,

--- a/core/src/test/java/io/github/theodoremeyer/simplevoicegeyser/core/audio/AudioThreadLifecycleTest.java
+++ b/core/src/test/java/io/github/theodoremeyer/simplevoicegeyser/core/audio/AudioThreadLifecycleTest.java
@@ -1,0 +1,30 @@
+package io.github.theodoremeyer.simplevoicegeyser.core.audio;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AudioThreadLifecycleTest {
+
+    @Test
+    void shutdownRejectsNewWorkIdempotently() throws Exception {
+        new AudioThread();
+        CountDownLatch ran = new CountDownLatch(1);
+        AudioThread.execute(ran::countDown);
+        assertTrue(ran.await(2, TimeUnit.SECONDS));
+
+        AudioThread.shutdown();
+        AudioThread.shutdown();
+
+        assertFalse(AudioThread.isAccepting());
+        AtomicBoolean afterShutdown = new AtomicBoolean(false);
+        AudioThread.execute(() -> afterShutdown.set(true));
+        Thread.sleep(100);
+        assertFalse(afterShutdown.get());
+    }
+}

--- a/core/src/test/java/io/github/theodoremeyer/simplevoicegeyser/core/audio/SvgAudioListenerTest.java
+++ b/core/src/test/java/io/github/theodoremeyer/simplevoicegeyser/core/audio/SvgAudioListenerTest.java
@@ -9,6 +9,8 @@ import io.github.theodoremeyer.simplevoicegeyser.core.api.Platform;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.chat.SvgLogger;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.data.DataType;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.data.SvgFile;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.DirectTaskScheduler;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
 import io.github.theodoremeyer.simplevoicegeyser.core.svc.VoiceChatBridge;
 import org.eclipse.jetty.websocket.api.Session;
 import org.junit.jupiter.api.Test;
@@ -137,6 +139,7 @@ class SvgAudioListenerTest {
     private static final class FakePlatform implements Platform {
         private final SvgFile config = new FakeSvgFile();
         private final SvgLogger logger = new NoopLogger();
+        private final TaskScheduler taskScheduler = new DirectTaskScheduler();
 
         @Override
         public void disable() {
@@ -180,6 +183,11 @@ class SvgAudioListenerTest {
         @Override
         public boolean isDependencyEnabled(String name) {
             return false;
+        }
+
+        @Override
+        public TaskScheduler getTaskScheduler() {
+            return taskScheduler;
         }
     }
 

--- a/core/src/test/java/io/github/theodoremeyer/simplevoicegeyser/core/managers/PlayerManagerConcurrencyTest.java
+++ b/core/src/test/java/io/github/theodoremeyer/simplevoicegeyser/core/managers/PlayerManagerConcurrencyTest.java
@@ -1,0 +1,172 @@
+package io.github.theodoremeyer.simplevoicegeyser.core.managers;
+
+import io.github.theodoremeyer.simplevoicegeyser.core.SvgCore;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.Platform;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.chat.SvgLogger;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.data.DataType;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.data.SvgFile;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.sender.SvgPlayer;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.DirectTaskScheduler;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
+import io.github.theodoremeyer.simplevoicegeyser.core.svc.VoiceChatBridge;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PlayerManagerConcurrencyTest {
+
+    @BeforeEach
+    void setUp() {
+        new SvgCore(new FakePlatform());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SvgCore.disable();
+    }
+
+    @Test
+    void staleRemoveDoesNotDropReplacementPlayer() {
+        PlayerManager manager = SvgCore.getPlayerManager();
+        UUID uuid = UUID.randomUUID();
+
+        FakePlayer first = new FakePlayer(uuid, "Steve");
+        FakePlayer second = new FakePlayer(uuid, "Steve");
+
+        manager.addPlayer(first);
+        manager.addPlayer(second);
+
+        assertSame(second, manager.getPlayer(uuid));
+
+        manager.removePlayer(first);
+
+        assertSame(second, manager.getPlayer(uuid));
+        assertSame(second, manager.getPlayer("Steve"));
+    }
+
+    @Test
+    void removeCurrentPlayerClearsMappings() {
+        PlayerManager manager = SvgCore.getPlayerManager();
+        FakePlayer player = new FakePlayer(UUID.randomUUID(), "Alex");
+        manager.addPlayer(player);
+        manager.removePlayer(player);
+
+        assertNull(manager.getPlayer(player.getUniqueId()));
+        assertNull(manager.getPlayer("Alex"));
+    }
+
+    private static final class FakePlayer extends SvgPlayer {
+        private final UUID uuid;
+        private final String name;
+        private final AtomicBoolean online = new AtomicBoolean(true);
+
+        private FakePlayer(UUID uuid, String name) {
+            this.uuid = uuid;
+            this.name = name;
+        }
+
+        @Override
+        public UUID getUniqueId() {
+            return uuid;
+        }
+
+        @Override
+        public boolean hasPermission(String permission) {
+            return true;
+        }
+
+        @Override
+        public void chat(String message) {
+        }
+
+        @Override
+        public boolean isOnline() {
+            return online.get();
+        }
+
+        @Override
+        public Object getPlayer() {
+            return null;
+        }
+
+        @Override
+        public void sendMessage(String message) {
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+
+    private static final class FakePlatform implements Platform {
+        private final SvgFile config = new FakeSvgFile();
+        private final TaskScheduler scheduler = new DirectTaskScheduler();
+        private final SvgLogger logger = new NoopLogger();
+
+        @Override public void disable() {}
+        @Override public String getPrefix() { return ""; }
+        @Override public String getServerMcVersion() { return "test"; }
+        @Override public String getServerPlatform() { return "test"; }
+        @Override public VoiceChatBridge registerVcBridge() { return null; }
+        @Override public SvgLogger getSvgLogger() { return logger; }
+        @Override public SvgFile getFile(DataType type) { return config; }
+        @Override public File getDataFolder() { return new File("."); }
+        @Override public boolean isDependencyEnabled(String name) { return false; }
+        @Override public TaskScheduler getTaskScheduler() { return scheduler; }
+    }
+
+    private static final class FakeSvgFile extends SvgFile {
+        private final Map<String, Object> values = new LinkedHashMap<>(Map.of("updatechecker.enable", false));
+
+        @Override public Set<String> getKeys() { return values.keySet(); }
+        @Override public boolean has(String key) { return values.containsKey(key); }
+        @Override public void set(String path, Object value) { values.put(path, value); }
+        @Override public String getString(String path) { return getString(path, null); }
+        @Override public String getString(String path, String def) {
+            Object value = values.get(path);
+            return value == null ? def : String.valueOf(value);
+        }
+        @Override public boolean getBoolean(String path, boolean def) {
+            Object value = values.get(path);
+            return value instanceof Boolean bool ? bool : def;
+        }
+        @Override public int getInt(String path, int def) {
+            Object value = values.get(path);
+            return value instanceof Number number ? number.intValue() : def;
+        }
+        @Override public void save() {}
+        @Override public void reload() {}
+        @Override public File getFile() { return new File("test-config.yml"); }
+        @Override public String backup() { return ""; }
+        @Override public double getDouble(String path, double def) {
+            Object value = values.get(path);
+            return value instanceof Number number ? number.doubleValue() : def;
+        }
+        @Override
+        @SuppressWarnings("unchecked")
+        public List<String> getStringList(String path, List<String> def) {
+            Object value = values.get(path);
+            return value instanceof List<?> list ? (List<String>) list : def;
+        }
+    }
+
+    private static final class NoopLogger implements SvgLogger {
+        @Override public void info(String msg) {}
+        @Override public void warning(String msg) {}
+        @Override public void error(String msg) {}
+        @Override public void severe(String msg) {}
+        @Override public void error(String msg, Throwable t) {}
+    }
+}

--- a/core/src/test/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/DirectTaskSchedulerTest.java
+++ b/core/src/test/java/io/github/theodoremeyer/simplevoicegeyser/core/schedule/DirectTaskSchedulerTest.java
@@ -1,0 +1,98 @@
+package io.github.theodoremeyer.simplevoicegeyser.core.schedule;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DirectTaskSchedulerTest {
+
+    @Test
+    void selectsNonRegionThreadedBackend() {
+        DirectTaskScheduler scheduler = new DirectTaskScheduler();
+        assertFalse(scheduler.isRegionThreaded());
+        assertTrue(scheduler.isAcceptingTasks());
+        scheduler.shutdown();
+    }
+
+    @Test
+    void cancelAsyncTaskPreventsExecution() throws Exception {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            DirectTaskScheduler scheduler = new DirectTaskScheduler(uuid -> true, executor, false);
+            AtomicBoolean ran = new AtomicBoolean(false);
+            CountDownLatch started = new CountDownLatch(1);
+
+            ScheduledTask task = scheduler.runAsyncLater("svg/test/cancel", () -> {
+                started.countDown();
+                ran.set(true);
+            }, 200, TimeUnit.MILLISECONDS);
+
+            task.cancel();
+            assertTrue(task.isCancelled());
+            assertFalse(started.await(350, TimeUnit.MILLISECONDS));
+            assertFalse(ran.get());
+            scheduler.shutdown();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void shutdownRejectsNewWorkAndIsIdempotent() {
+        DirectTaskScheduler scheduler = new DirectTaskScheduler();
+        AtomicInteger runs = new AtomicInteger();
+
+        scheduler.runGlobal("svg/test/before-shutdown", runs::incrementAndGet);
+        assertEquals(1, runs.get());
+
+        scheduler.shutdown();
+        scheduler.shutdown();
+
+        assertFalse(scheduler.isAcceptingTasks());
+        ScheduledTask rejected = scheduler.runGlobal("svg/test/after-shutdown", runs::incrementAndGet);
+        assertTrue(rejected.isCancelled());
+        assertEquals(1, runs.get());
+    }
+
+    @Test
+    void entityRetirementCallbackRunsWhenEntityMissing() {
+        UUID missing = UUID.randomUUID();
+        DirectTaskScheduler scheduler = new DirectTaskScheduler(uuid -> false, Executors.newSingleThreadScheduledExecutor(), true);
+        AtomicBoolean retired = new AtomicBoolean(false);
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        ScheduledTask task = scheduler.runForEntity(
+                "svg/test/entity-retired",
+                missing,
+                () -> ran.set(true),
+                () -> retired.set(true)
+        );
+
+        assertTrue(task.isCancelled());
+        assertTrue(retired.get());
+        assertFalse(ran.get());
+        scheduler.shutdown();
+    }
+
+    @Test
+    void entityTaskRunsWhenEntityPresent() {
+        UUID present = UUID.randomUUID();
+        DirectTaskScheduler scheduler = new DirectTaskScheduler(uuid -> uuid.equals(present), Executors.newSingleThreadScheduledExecutor(), true);
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        scheduler.executeForEntity("svg/test/entity-present", present, () -> ran.set(true), null);
+
+        assertTrue(ran.get());
+        scheduler.shutdown();
+    }
+}

--- a/core/src/test/java/io/github/theodoremeyer/simplevoicegeyser/core/server/connection/ConnectionManagerConcurrencyTest.java
+++ b/core/src/test/java/io/github/theodoremeyer/simplevoicegeyser/core/server/connection/ConnectionManagerConcurrencyTest.java
@@ -1,0 +1,316 @@
+package io.github.theodoremeyer.simplevoicegeyser.core.server.connection;
+
+import io.github.theodoremeyer.simplevoicegeyser.core.SvgCore;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.Platform;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.chat.SvgLogger;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.data.DataType;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.data.SvgFile;
+import io.github.theodoremeyer.simplevoicegeyser.core.api.sender.SvgPlayer;
+import io.github.theodoremeyer.simplevoicegeyser.core.audio.AudioSessionNegotiation;
+import io.github.theodoremeyer.simplevoicegeyser.core.audio.AudioTransportMode;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.DirectTaskScheduler;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
+import io.github.theodoremeyer.simplevoicegeyser.core.server.connection.compatibility.ClientIdentity;
+import io.github.theodoremeyer.simplevoicegeyser.core.svc.VoiceChatBridge;
+import org.eclipse.jetty.websocket.api.RemoteEndpoint;
+import org.eclipse.jetty.websocket.api.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Proxy;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConnectionManagerConcurrencyTest {
+
+    @BeforeEach
+    void setUp() {
+        new SvgCore(new FakePlatform());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SvgCore.disable();
+    }
+
+    @Test
+    void shutdownRejectsNewConnectionsIdempotently() {
+        ConnectionManager manager = new ConnectionManager();
+        FakePlayer player = new FakePlayer();
+
+        SvgConnection first = manager.connect(
+                openSession(),
+                player,
+                negotiation(),
+                ClientIdentity.web("0.1.3", "test")
+        );
+        assertSame(first, manager.get(player.getUniqueId()));
+
+        manager.disconnectAll();
+        manager.disconnectAll();
+
+        assertFalse(manager.isAcceptingConnections());
+        assertNull(manager.get(player.getUniqueId()));
+        assertThrows(IllegalStateException.class, () -> manager.connect(
+                openSession(),
+                player,
+                negotiation(),
+                ClientIdentity.web("0.1.3", "test")
+        ));
+    }
+
+    @Test
+    void sessionReplacementDisconnectsPreviousConnection() {
+        ConnectionManager manager = new ConnectionManager();
+        FakePlayer player = new FakePlayer();
+
+        SvgConnection first = manager.connect(
+                openSession(),
+                player,
+                negotiation(),
+                ClientIdentity.web("0.1.3", "test")
+        );
+        SvgConnection second = manager.connect(
+                openSession(),
+                player,
+                negotiation(),
+                ClientIdentity.web("0.1.3", "test")
+        );
+
+        assertNotSame(first, second);
+        assertSame(second, manager.get(player.getUniqueId()));
+        assertTrue(first.isClosed());
+        assertFalse(second.isClosed());
+    }
+
+    @Test
+    void concurrentJoinAndLeaveDoNotCorruptMap() throws Exception {
+        ConnectionManager manager = new ConnectionManager();
+        FakePlayer player = new FakePlayer();
+        UUID uuid = player.getUniqueId();
+        ExecutorService pool = Executors.newFixedThreadPool(4);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger connects = new AtomicInteger();
+
+        try {
+            for (int i = 0; i < 20; i++) {
+                pool.execute(() -> {
+                    await(start);
+                    try {
+                        manager.connect(
+                                openSession(),
+                                player,
+                                negotiation(),
+                                ClientIdentity.web("0.1.3", "test")
+                        );
+                        connects.incrementAndGet();
+                    } catch (IllegalStateException ignored) {
+                    }
+                });
+                pool.execute(() -> {
+                    await(start);
+                    manager.disconnect(uuid, 4003, "leave");
+                });
+            }
+
+            start.countDown();
+            pool.shutdown();
+            assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+
+            SvgConnection remaining = manager.get(uuid);
+            if (remaining != null) {
+                assertFalse(remaining.isClosed());
+            }
+            assertTrue(connects.get() > 0);
+        } finally {
+            pool.shutdownNow();
+            manager.disconnectAll();
+        }
+    }
+
+    @Test
+    void removeIgnoresStaleConnectionAfterReplacement() {
+        ConnectionManager manager = new ConnectionManager();
+        FakePlayer player = new FakePlayer();
+
+        SvgConnection first = manager.connect(
+                openSession(),
+                player,
+                negotiation(),
+                ClientIdentity.web("0.1.3", "test")
+        );
+        SvgConnection second = manager.connect(
+                openSession(),
+                player,
+                negotiation(),
+                ClientIdentity.web("0.1.3", "test")
+        );
+
+        manager.remove(first);
+        assertSame(second, manager.get(player.getUniqueId()));
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static AudioSessionNegotiation negotiation() {
+        return new AudioSessionNegotiation(AudioTransportMode.SVG_V2, true);
+    }
+
+    private static Session openSession() {
+        RemoteEndpoint remote = proxy(RemoteEndpoint.class, invocation -> null);
+        return proxy(Session.class, invocation -> switch (invocation.methodName()) {
+            case "isOpen" -> true;
+            case "getRemote" -> remote;
+            case "close" -> null;
+            default -> defaultValue(invocation.returnType());
+        });
+    }
+
+    private static final class FakePlayer extends SvgPlayer {
+        private final UUID uuid = UUID.randomUUID();
+
+        @Override
+        public UUID getUniqueId() {
+            return uuid;
+        }
+
+        @Override
+        public boolean hasPermission(String permission) {
+            return true;
+        }
+
+        @Override
+        public void chat(String message) {
+        }
+
+        @Override
+        public boolean isOnline() {
+            return true;
+        }
+
+        @Override
+        public Object getPlayer() {
+            return null;
+        }
+
+        @Override
+        public void sendMessage(String message) {
+        }
+
+        @Override
+        public String getName() {
+            return "Player";
+        }
+    }
+
+    private static final class FakePlatform implements Platform {
+        private final SvgFile config = new FakeSvgFile();
+        private final TaskScheduler scheduler = new DirectTaskScheduler();
+        private final SvgLogger logger = new NoopLogger();
+
+        @Override public void disable() {}
+        @Override public String getPrefix() { return ""; }
+        @Override public String getServerMcVersion() { return "test"; }
+        @Override public String getServerPlatform() { return "test"; }
+        @Override public VoiceChatBridge registerVcBridge() { return null; }
+        @Override public SvgLogger getSvgLogger() { return logger; }
+        @Override public SvgFile getFile(DataType type) { return config; }
+        @Override public File getDataFolder() { return new File("."); }
+        @Override public boolean isDependencyEnabled(String name) { return false; }
+        @Override public TaskScheduler getTaskScheduler() { return scheduler; }
+    }
+
+    private static final class FakeSvgFile extends SvgFile {
+        private final Map<String, Object> values = new LinkedHashMap<>(Map.of("updatechecker.enable", false));
+
+        @Override public Set<String> getKeys() { return values.keySet(); }
+        @Override public boolean has(String key) { return values.containsKey(key); }
+        @Override public void set(String path, Object value) { values.put(path, value); }
+        @Override public String getString(String path) { return getString(path, null); }
+        @Override public String getString(String path, String def) {
+            Object value = values.get(path);
+            return value == null ? def : String.valueOf(value);
+        }
+        @Override public boolean getBoolean(String path, boolean def) {
+            Object value = values.get(path);
+            return value instanceof Boolean bool ? bool : def;
+        }
+        @Override public int getInt(String path, int def) {
+            Object value = values.get(path);
+            return value instanceof Number number ? number.intValue() : def;
+        }
+        @Override public void save() {}
+        @Override public void reload() {}
+        @Override public File getFile() { return new File("test-config.yml"); }
+        @Override public String backup() { return ""; }
+        @Override public double getDouble(String path, double def) {
+            Object value = values.get(path);
+            return value instanceof Number number ? number.doubleValue() : def;
+        }
+        @Override
+        @SuppressWarnings("unchecked")
+        public List<String> getStringList(String path, List<String> def) {
+            Object value = values.get(path);
+            return value instanceof List<?> list ? (List<String>) list : def;
+        }
+    }
+
+    private static final class NoopLogger implements SvgLogger {
+        @Override public void info(String msg) {}
+        @Override public void warning(String msg) {}
+        @Override public void error(String msg) {}
+        @Override public void severe(String msg) {}
+        @Override public void error(String msg, Throwable t) {}
+    }
+
+    private record Invocation(String methodName, Class<?> returnType, Object[] args) {
+    }
+
+    private interface Handler {
+        Object handle(Invocation invocation) throws Throwable;
+    }
+
+    private static <T> T proxy(Class<T> type, Handler handler) {
+        Object proxy = Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[]{type},
+                (proxyObj, method, args) -> handler.handle(
+                        new Invocation(method.getName(), method.getReturnType(), args == null ? new Object[0] : args)
+                )
+        );
+        return type.cast(proxy);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == int.class || type == long.class || type == float.class || type == double.class) {
+            return 0;
+        }
+        return null;
+    }
+}

--- a/fabric/src/main/java/io/github/theodoremeyer/simplevoicegeyser/fabric/SvgMod.java
+++ b/fabric/src/main/java/io/github/theodoremeyer/simplevoicegeyser/fabric/SvgMod.java
@@ -6,6 +6,8 @@ import io.github.theodoremeyer.simplevoicegeyser.core.api.chat.SvgColor;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.chat.SvgLogger;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.data.DataType;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.data.SvgFile;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.DirectTaskScheduler;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
 import io.github.theodoremeyer.simplevoicegeyser.core.svc.VoiceChatBridge;
 import io.github.theodoremeyer.simplevoicegeyser.fabric.hooks.LuckPermsHook;
 import io.github.theodoremeyer.simplevoicegeyser.fabric.impl.FabricCommand;
@@ -33,6 +35,8 @@ public class SvgMod implements ModInitializer, Platform {
     private ConfigFile configFile;
 
     private final FabricLogger logger = new FabricLogger();
+
+    private final TaskScheduler taskScheduler = new DirectTaskScheduler();
 
     private static boolean ready = false;
 
@@ -183,5 +187,10 @@ public class SvgMod implements ModInitializer, Platform {
         } catch (ClassNotFoundException e) {
             return false;
         }
+    }
+
+    @Override
+    public TaskScheduler getTaskScheduler() {
+        return taskScheduler;
     }
 }

--- a/fabric/src/main/java/io/github/theodoremeyer/simplevoicegeyser/fabric/impl/sender/FabricPlayer.java
+++ b/fabric/src/main/java/io/github/theodoremeyer/simplevoicegeyser/fabric/impl/sender/FabricPlayer.java
@@ -65,5 +65,9 @@ public class FabricPlayer extends SvgPlayer {
         return player.getName().getString();
     }
 
+    @Override
+    public Double getLookYawDegrees() {
+        return (double) player.getYRot();
+    }
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "SimpleVoice-Geyser"
 
 include("core", "spigot", "fabric")

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -19,6 +19,15 @@ dependencies {
 
     // Simple Voice Chat API
     compileOnly("de.maxhenkel.voicechat:voicechat-api:${voicechat_api_version}")
+
+    testImplementation(platform("org.junit:junit-bom:5.12.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.spigotmc:spigot-api:${spigot_api_version}-R0.1-SNAPSHOT")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 tasks.processResources {

--- a/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/SvgPlugin.java
+++ b/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/SvgPlugin.java
@@ -6,11 +6,13 @@ import io.github.theodoremeyer.simplevoicegeyser.core.api.Platform;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.chat.SvgLogger;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.data.DataType;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.data.SvgFile;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
 import io.github.theodoremeyer.simplevoicegeyser.core.svc.VoiceChatBridge;
 import io.github.theodoremeyer.simplevoicegeyser.spigotmc.impl.BukkitLogger;
 import io.github.theodoremeyer.simplevoicegeyser.spigotmc.impl.SvgCommand;
 import io.github.theodoremeyer.simplevoicegeyser.spigotmc.impl.SvgListener;
 import io.github.theodoremeyer.simplevoicegeyser.spigotmc.impl.data.ConfigFile;
+import io.github.theodoremeyer.simplevoicegeyser.spigotmc.schedule.PlatformSchedulers;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.PluginCommand;
@@ -26,10 +28,13 @@ public class SvgPlugin extends JavaPlugin implements Platform {
 
     private BukkitLogger logger;
 
+    private TaskScheduler taskScheduler;
+
     //JAVA PLUGIN
     @Override
     public void onLoad() {
         logger = new BukkitLogger(getLogger());
+        this.taskScheduler = PlatformSchedulers.create(this);
 
         // Ensure plugin folder exists
         if (!getDataFolder().exists()) {
@@ -49,6 +54,14 @@ public class SvgPlugin extends JavaPlugin implements Platform {
 
         // Initialize ConfigFile wrapper
         this.configFile = new ConfigFile(file);
+
+        if (taskScheduler.isRegionThreaded()) {
+            logger.info("Detected regionized threading (Folia/Canvas). Using region/entity schedulers.");
+        } else if (PlatformSchedulers.hasRegionSchedulers(getServer())) {
+            logger.info("Using Paper region scheduler API (mapped to the server tick thread).");
+        } else {
+            logger.info("Using classic Bukkit scheduler.");
+        }
 
         this.core = new SvgCore(this);
     }
@@ -142,5 +155,10 @@ public class SvgPlugin extends JavaPlugin implements Platform {
     @Override
     public boolean isDependencyEnabled(String name) {
         return Bukkit.getPluginManager().isPluginEnabled(name);
+    }
+
+    @Override
+    public TaskScheduler getTaskScheduler() {
+        return taskScheduler;
     }
 }

--- a/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/impl/SvgListener.java
+++ b/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/impl/SvgListener.java
@@ -6,12 +6,18 @@ import io.github.theodoremeyer.simplevoicegeyser.spigotmc.impl.sender.BukkitPlay
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.UUID;
 
+/**
+ * Player lifecycle listener. Join/quit/move handlers run on the player's owning
+ * region on Folia/Canvas, so entity reads here are safe.
+ */
 public class SvgListener implements Listener {
 
     @EventHandler
@@ -25,10 +31,31 @@ public class SvgListener implements Listener {
         SvgCore.getPlayerManager().addPlayer(new BukkitPlayer(player));
     }
 
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onMove(PlayerMoveEvent event) {
+        // Keep a yaw snapshot for spatial audio without reading entity state from SVG-Audio.
+        if (event.getTo() == null) {
+            return;
+        }
+        if (event.getFrom().getYaw() == event.getTo().getYaw()
+                && event.getFrom().getPitch() == event.getTo().getPitch()) {
+            return;
+        }
+
+        SvgPlayer svgPlayer = SvgCore.getPlayerManager().getPlayer(event.getPlayer().getUniqueId());
+        if (svgPlayer instanceof BukkitPlayer bukkitPlayer) {
+            bukkitPlayer.updateCachedYaw(event.getTo().getYaw());
+        }
+    }
+
     @EventHandler
     public void onLeave(PlayerQuitEvent event) {
         UUID playerUuid = event.getPlayer().getUniqueId();
         SvgPlayer player = SvgCore.getPlayerManager().getPlayer(playerUuid);
+
+        if (player instanceof BukkitPlayer bukkitPlayer) {
+            bukkitPlayer.markOffline();
+        }
 
         if (player != null) {
             SvgCore.getPlayerManager().removePlayer(player);

--- a/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/impl/sender/BukkitPlayer.java
+++ b/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/impl/sender/BukkitPlayer.java
@@ -2,72 +2,189 @@ package io.github.theodoremeyer.simplevoicegeyser.spigotmc.impl.sender;
 
 import io.github.theodoremeyer.simplevoicegeyser.core.SvgCore;
 import io.github.theodoremeyer.simplevoicegeyser.core.api.sender.SvgPlayer;
-import io.github.theodoremeyer.simplevoicegeyser.spigotmc.SvgPlugin;
-import org.bukkit.Bukkit;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
+/**
+ * Bukkit/Paper/Folia player bridge.
+ * <p>
+ * Identity and permission snapshots are retained as immutable/thread-safe data so
+ * browser, Geyser, and audio threads do not touch live entity state off-region.
+ * Mutations such as chat and messages are marshalled onto the entity scheduler.
+ */
 public class BukkitPlayer extends SvgPlayer {
 
-    private final Player player;
+    private static final String[] CACHED_PERMISSIONS = {
+            "svg.admin",
+            "svg.vc",
+            "svg.vc.join",
+            "svg.vc.group",
+            "svg.vc.group.create",
+            "svg.vc.group.join",
+            "svg.vc.group.type",
+            "svg.vc.group.type.isolated",
+            "svg.vc.group.setpersistent",
+            "svg.vc.group.setpersistant"
+    };
 
+    private final Player player;
+    private final UUID uniqueId;
+    private final String name;
+    private final AtomicBoolean online = new AtomicBoolean(true);
+    private final AtomicReference<Double> cachedYawDegrees = new AtomicReference<>();
+    private final Map<String, Boolean> permissionCache = new ConcurrentHashMap<>();
+
+    /**
+     * @param player online Bukkit player; must be called on the owning region/thread
+     */
     public BukkitPlayer(Player player) {
         this.player = player;
+        this.uniqueId = player.getUniqueId();
+        this.name = player.getName();
+        refreshOwnedState(player);
+    }
+
+    /**
+     * Refresh yaw/permission snapshots. Must run on the player's owning region.
+     * @param player live player
+     */
+    public void refreshOwnedState(Player player) {
+        if (player == null || !player.getUniqueId().equals(uniqueId)) {
+            return;
+        }
+        cachedYawDegrees.set((double) player.getLocation().getYaw());
+        for (String permission : CACHED_PERMISSIONS) {
+            permissionCache.put(permission, player.hasPermission(permission));
+        }
+    }
+
+    /**
+     * Update only the cached look yaw. Must run on the player's owning region.
+     * @param yawDegrees yaw in degrees
+     */
+    public void updateCachedYaw(float yawDegrees) {
+        cachedYawDegrees.set((double) yawDegrees);
+    }
+
+    /**
+     * Mark the player offline for async readers.
+     */
+    public void markOffline() {
+        online.set(false);
     }
 
     @Override
     public UUID getUniqueId() {
-        return player.getUniqueId();
+        return uniqueId;
     }
 
     @Override
     public String getName() {
-        return player.getName();
+        return name;
     }
 
     @Override
     public boolean hasPermission(String permission) {
-        return player.hasPermission(permission);
+        if (permission == null) {
+            return false;
+        }
+
+        Boolean cached = permissionCache.get(permission);
+        if (cached != null) {
+            return cached;
+        }
+
+        // Off-thread / uncached: schedule a refresh and follow SvgPlayer's
+        // documented fallback (allow + log) rather than blocking a WS/audio thread.
+        TaskScheduler scheduler = SvgCore.getTaskScheduler();
+        scheduler.executeForEntity(
+                "svg/player/permission-refresh",
+                uniqueId,
+                () -> {
+                    Player live = resolveOnlinePlayer();
+                    if (live != null) {
+                        permissionCache.put(permission, live.hasPermission(permission));
+                    }
+                },
+                null
+        );
+
+        SvgCore.getLogger().warning(
+                "[Permissions] Off-thread permission check for '"
+                        + permission
+                        + "' without cache for "
+                        + name
+                        + "; defaulting to true until entity refresh completes."
+        );
+        return true;
     }
 
     @Override
     public void chat(String message) {
-        if (Bukkit.isPrimaryThread()) {
-            player.chat(message);
-        } else {
-            SvgPlugin plugin = (SvgPlugin) SvgCore.getPlatform();
-
-            Bukkit.getScheduler().runTask(plugin, () -> player.chat(message));
-        }
+        String outbound = message;
+        SvgCore.getTaskScheduler().executeForEntity(
+                "svg/player/chat",
+                uniqueId,
+                () -> {
+                    Player live = resolveOnlinePlayer();
+                    if (live != null) {
+                        live.chat(outbound);
+                    }
+                },
+                null
+        );
     }
 
     @Override
     public boolean isOnline() {
-        return player.isOnline();
+        return online.get();
     }
 
     @Override
     public Object getPlayer() {
+        // Live Bukkit entity. Callers must not touch entity state off the owning region;
+        // prefer UUID snapshots and {@link #getLookYawDegrees()} across threads.
         return player;
     }
 
     @Override
     public void sendMessage(String message) {
-        runOnMainThread(() -> player.sendMessage(translate(message)));
+        String translated = translate(message);
+        SvgCore.getTaskScheduler().executeForEntity(
+                "svg/player/send-message",
+                uniqueId,
+                () -> {
+                    Player live = resolveOnlinePlayer();
+                    if (live != null) {
+                        live.sendMessage(translated);
+                    }
+                },
+                null
+        );
     }
 
-    private void runOnMainThread(Runnable task) {
-        if (Bukkit.isPrimaryThread()) {
-            task.run();
-            return;
-        }
+    @Override
+    public Double getLookYawDegrees() {
+        return cachedYawDegrees.get();
+    }
 
-        Bukkit.getScheduler().runTask(
-                SvgPlugin.getPlugin(SvgPlugin.class),
-                task
-        );
+    private Player resolveOnlinePlayer() {
+        if (!online.get()) {
+            return null;
+        }
+        org.bukkit.entity.Player live = org.bukkit.Bukkit.getPlayer(uniqueId);
+        if (live == null || !live.isOnline()) {
+            online.set(false);
+            return null;
+        }
+        return live;
     }
 
     private String translate(String message) {

--- a/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/schedule/BukkitTaskScheduler.java
+++ b/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/schedule/BukkitTaskScheduler.java
@@ -1,0 +1,264 @@
+package io.github.theodoremeyer.simplevoicegeyser.spigotmc.schedule;
+
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.CancelledTask;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.NamedTask;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.ScheduledTask;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Classic Bukkit/Spigot scheduler adapter (single primary thread).
+ */
+public final class BukkitTaskScheduler implements TaskScheduler {
+
+    private final JavaPlugin plugin;
+    private final AtomicBoolean accepting = new AtomicBoolean(true);
+    private final Set<BukkitScheduledTask> tracked = ConcurrentHashMap.newKeySet();
+
+    /**
+     * @param plugin owning plugin
+     */
+    public BukkitTaskScheduler(JavaPlugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+    }
+
+    @Override
+    public boolean isAcceptingTasks() {
+        // Do not gate on JavaPlugin#isEnabled(): onDisable may run after the plugin
+        // is marked disabled, and we still need to finish entity-owned cleanup.
+        return accepting.get();
+    }
+
+    @Override
+    public boolean isRegionThreaded() {
+        return false;
+    }
+
+    @Override
+    public void shutdown() {
+        accepting.set(false);
+        cancelAll();
+        try {
+            Bukkit.getScheduler().cancelTasks(plugin);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    @Override
+    public void cancelAll() {
+        for (BukkitScheduledTask task : tracked) {
+            task.cancel();
+        }
+        tracked.clear();
+    }
+
+    @Override
+    public ScheduledTask runGlobal(String taskName, Runnable task) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        NamedTask named = new NamedTask(taskName, task);
+        if (Bukkit.isPrimaryThread()) {
+            named.run();
+            return CancelledTask.INSTANCE;
+        }
+        return track(Bukkit.getScheduler().runTask(plugin, named));
+    }
+
+    @Override
+    public ScheduledTask runGlobalLater(String taskName, Runnable task, long delayTicks) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        return track(Bukkit.getScheduler().runTaskLater(
+                plugin,
+                new NamedTask(taskName, task),
+                Math.max(0L, delayTicks)
+        ));
+    }
+
+    @Override
+    public ScheduledTask runGlobalTimer(String taskName, Runnable task, long delayTicks, long periodTicks) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        return track(Bukkit.getScheduler().runTaskTimer(
+                plugin,
+                new NamedTask(taskName, task),
+                Math.max(0L, delayTicks),
+                Math.max(1L, periodTicks)
+        ));
+    }
+
+    @Override
+    public ScheduledTask runAtLocation(
+            String taskName,
+            String worldName,
+            int blockX,
+            int blockY,
+            int blockZ,
+            Runnable task
+    ) {
+        // Classic servers have one global tick thread; still validate the world exists.
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        World world = worldName == null ? null : Bukkit.getWorld(worldName);
+        if (world == null) {
+            return CancelledTask.INSTANCE;
+        }
+        return runGlobal(taskName, task);
+    }
+
+    @Override
+    public ScheduledTask runForEntity(String taskName, UUID entityId, Runnable task, Runnable retired) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        Player player = entityId == null ? null : Bukkit.getPlayer(entityId);
+        if (player == null || !player.isOnline()) {
+            runRetired(retired);
+            return CancelledTask.INSTANCE;
+        }
+        return runGlobal(taskName, () -> {
+            Player online = Bukkit.getPlayer(entityId);
+            if (online == null || !online.isOnline()) {
+                runRetired(retired);
+                return;
+            }
+            new NamedTask(taskName, task).run();
+        });
+    }
+
+    @Override
+    public ScheduledTask runForEntityLater(
+            String taskName,
+            UUID entityId,
+            Runnable task,
+            Runnable retired,
+            long delayTicks
+    ) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        return runGlobalLater(taskName, () -> {
+            Player online = entityId == null ? null : Bukkit.getPlayer(entityId);
+            if (online == null || !online.isOnline()) {
+                runRetired(retired);
+                return;
+            }
+            new NamedTask(taskName, task).run();
+        }, delayTicks);
+    }
+
+    @Override
+    public void executeForEntity(String taskName, UUID entityId, Runnable task, Runnable retired) {
+        if (!isAcceptingTasks()) {
+            return;
+        }
+        Player player = entityId == null ? null : Bukkit.getPlayer(entityId);
+        if (player == null || !player.isOnline()) {
+            runRetired(retired);
+            return;
+        }
+        if (Bukkit.isPrimaryThread()) {
+            new NamedTask(taskName, task).run();
+            return;
+        }
+        runForEntity(taskName, entityId, task, retired);
+    }
+
+    @Override
+    public ScheduledTask runAsync(String taskName, Runnable task) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        return track(Bukkit.getScheduler().runTaskAsynchronously(plugin, new NamedTask(taskName, task)));
+    }
+
+    @Override
+    public ScheduledTask runAsyncLater(String taskName, Runnable task, long delay, TimeUnit unit) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        long ticks = Math.max(0L, unit.toMillis(delay) / 50L);
+        return track(Bukkit.getScheduler().runTaskLaterAsynchronously(
+                plugin,
+                new NamedTask(taskName, task),
+                ticks
+        ));
+    }
+
+    @Override
+    public ScheduledTask runAsyncTimer(
+            String taskName,
+            Runnable task,
+            long delay,
+            long period,
+            TimeUnit unit
+    ) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        long delayTicks = Math.max(0L, unit.toMillis(delay) / 50L);
+        long periodTicks = Math.max(1L, unit.toMillis(period) / 50L);
+        return track(Bukkit.getScheduler().runTaskTimerAsynchronously(
+                plugin,
+                new NamedTask(taskName, task),
+                delayTicks,
+                periodTicks
+        ));
+    }
+
+    private ScheduledTask track(BukkitTask bukkitTask) {
+        BukkitScheduledTask wrapped = new BukkitScheduledTask(bukkitTask);
+        tracked.add(wrapped);
+        return wrapped;
+    }
+
+    private void runRetired(Runnable retired) {
+        if (retired == null) {
+            return;
+        }
+        try {
+            retired.run();
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private final class BukkitScheduledTask implements ScheduledTask {
+        private final BukkitTask bukkitTask;
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        private BukkitScheduledTask(BukkitTask bukkitTask) {
+            this.bukkitTask = bukkitTask;
+        }
+
+        @Override
+        public void cancel() {
+            if (cancelled.compareAndSet(false, true)) {
+                try {
+                    bukkitTask.cancel();
+                } catch (Throwable ignored) {
+                }
+                tracked.remove(this);
+            }
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled.get() || bukkitTask.isCancelled();
+        }
+    }
+}

--- a/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/schedule/FoliaTaskScheduler.java
+++ b/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/schedule/FoliaTaskScheduler.java
@@ -1,0 +1,602 @@
+package io.github.theodoremeyer.simplevoicegeyser.spigotmc.schedule;
+
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.CancelledTask;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.NamedTask;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.ScheduledTask;
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/**
+ * Folia/Paper/Canvas region scheduler adapter.
+ * <p>
+ * Uses reflection against Paper's region scheduler API so Spigot classloading
+ * does not hard-link Folia-only types. On Paper, these schedulers map to the
+ * global tick thread; on Folia/Canvas they honor region ownership.
+ * <p>
+ * Canvas-specific profiling APIs are intentionally not used so this plugin is
+ * never Canvas-only. Task attribution relies on the owning {@link Plugin} plus
+ * stable {@link NamedTask} paths visible in Folia/Canvas profiler stacks.
+ */
+public final class FoliaTaskScheduler implements TaskScheduler {
+
+    private final JavaPlugin plugin;
+    private final boolean regionThreaded;
+    private final AtomicBoolean accepting = new AtomicBoolean(true);
+    private final Set<ReflectiveScheduledTask> tracked = ConcurrentHashMap.newKeySet();
+
+    private final Object globalScheduler;
+    private final Object regionScheduler;
+    private final Object asyncScheduler;
+
+    private final Method globalExecute;
+    private final Method globalRun;
+    private final Method globalRunDelayed;
+    private final Method globalRunAtFixedRate;
+    private final Method globalCancelTasks;
+
+    private final Method regionExecuteLocation;
+
+    private final Method asyncRunNow;
+    private final Method asyncRunDelayed;
+    private final Method asyncRunAtFixedRate;
+    private final Method asyncCancelTasks;
+
+    private final Method entityGetScheduler;
+    private final Method entitySchedulerExecute;
+    private final Method entitySchedulerRun;
+    private final Method entitySchedulerRunDelayed;
+
+    private final Method scheduledTaskCancel;
+    private final Method isOwnedByCurrentRegion;
+
+    /**
+     * @param plugin owning plugin
+     */
+    public FoliaTaskScheduler(JavaPlugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.regionThreaded = PlatformSchedulers.isRegionThreadedRuntime();
+
+        try {
+            Object server = Bukkit.getServer();
+            Class<?> serverClass = server.getClass();
+
+            globalScheduler = serverClass.getMethod("getGlobalRegionScheduler").invoke(server);
+            regionScheduler = serverClass.getMethod("getRegionScheduler").invoke(server);
+            asyncScheduler = serverClass.getMethod("getAsyncScheduler").invoke(server);
+
+            Class<?> globalClass = globalScheduler.getClass();
+            globalExecute = findMethod(globalClass, "execute", Plugin.class, Runnable.class);
+            globalRun = findMethod(globalClass, "run", Plugin.class, Consumer.class);
+            globalRunDelayed = findMethod(globalClass, "runDelayed", Plugin.class, Consumer.class, long.class);
+            globalRunAtFixedRate = findMethod(
+                    globalClass,
+                    "runAtFixedRate",
+                    Plugin.class,
+                    Consumer.class,
+                    long.class,
+                    long.class
+            );
+            globalCancelTasks = findMethod(globalClass, "cancelTasks", Plugin.class);
+
+            Class<?> regionClass = regionScheduler.getClass();
+            regionExecuteLocation = findMethod(
+                    regionClass,
+                    "execute",
+                    Plugin.class,
+                    Location.class,
+                    Runnable.class
+            );
+
+            Class<?> asyncClass = asyncScheduler.getClass();
+            asyncRunNow = findMethod(asyncClass, "runNow", Plugin.class, Consumer.class);
+            asyncRunDelayed = findMethod(
+                    asyncClass,
+                    "runDelayed",
+                    Plugin.class,
+                    Consumer.class,
+                    long.class,
+                    TimeUnit.class
+            );
+            asyncRunAtFixedRate = findMethod(
+                    asyncClass,
+                    "runAtFixedRate",
+                    Plugin.class,
+                    Consumer.class,
+                    long.class,
+                    long.class,
+                    TimeUnit.class
+            );
+            asyncCancelTasks = findMethod(asyncClass, "cancelTasks", Plugin.class);
+
+            // Resolve from the Paper/Folia EntityScheduler type when present so we do not
+            // depend on compile-time Entity#getScheduler being declared by spigot-api.
+            Method resolvedEntityGetScheduler;
+            Class<?> entitySchedulerType;
+            try {
+                entitySchedulerType = Class.forName(
+                        "io.papermc.paper.threadedregions.scheduler.EntityScheduler"
+                );
+                resolvedEntityGetScheduler = Entity.class.getMethod("getScheduler");
+            } catch (ClassNotFoundException | NoSuchMethodException ex) {
+                resolvedEntityGetScheduler = findMethod(Entity.class, "getScheduler");
+                entitySchedulerType = resolvedEntityGetScheduler.getReturnType();
+            }
+            entityGetScheduler = resolvedEntityGetScheduler;
+            entitySchedulerExecute = findMethod(
+                    entitySchedulerType,
+                    "execute",
+                    Plugin.class,
+                    Runnable.class,
+                    Runnable.class,
+                    long.class
+            );
+            entitySchedulerRun = findMethod(
+                    entitySchedulerType,
+                    "run",
+                    Plugin.class,
+                    Consumer.class,
+                    Runnable.class
+            );
+            entitySchedulerRunDelayed = findMethod(
+                    entitySchedulerType,
+                    "runDelayed",
+                    Plugin.class,
+                    Consumer.class,
+                    Runnable.class,
+                    long.class
+            );
+
+            Method cancel = null;
+            try {
+                Class<?> scheduledTaskClass = Class.forName(
+                        "io.papermc.paper.threadedregions.scheduler.ScheduledTask"
+                );
+                cancel = scheduledTaskClass.getMethod("cancel");
+            } catch (ClassNotFoundException ignored) {
+            }
+            scheduledTaskCancel = cancel;
+
+            Method owned = null;
+            try {
+                owned = serverClass.getMethod("isOwnedByCurrentRegion", Entity.class);
+            } catch (NoSuchMethodException ignored) {
+            }
+            isOwnedByCurrentRegion = owned;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to bind Folia/Paper region schedulers", e);
+        }
+    }
+
+    @Override
+    public boolean isAcceptingTasks() {
+        // Do not gate on JavaPlugin#isEnabled(): onDisable may run after the plugin
+        // is marked disabled, and we still need to finish entity-owned cleanup.
+        return accepting.get();
+    }
+
+    @Override
+    public boolean isRegionThreaded() {
+        return regionThreaded;
+    }
+
+    @Override
+    public void shutdown() {
+        accepting.set(false);
+        cancelAll();
+        try {
+            if (globalCancelTasks != null) {
+                globalCancelTasks.invoke(globalScheduler, plugin);
+            }
+            if (asyncCancelTasks != null) {
+                asyncCancelTasks.invoke(asyncScheduler, plugin);
+            }
+        } catch (Throwable ignored) {
+        }
+    }
+
+    @Override
+    public void cancelAll() {
+        for (ReflectiveScheduledTask task : tracked) {
+            task.cancel();
+        }
+        tracked.clear();
+    }
+
+    @Override
+    public ScheduledTask runGlobal(String taskName, Runnable task) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        NamedTask named = new NamedTask(taskName, task);
+        try {
+            if (isOwnedByGlobalRegion()) {
+                named.run();
+                return CancelledTask.INSTANCE;
+            }
+            if (globalExecute != null) {
+                globalExecute.invoke(globalScheduler, plugin, named);
+                return CancelledTask.INSTANCE;
+            }
+            Object foliaTask = globalRun.invoke(globalScheduler, plugin, asConsumer(named));
+            return track(foliaTask);
+        } catch (Throwable t) {
+            throw new IllegalStateException("Failed to schedule global task: " + taskName, t);
+        }
+    }
+
+    @Override
+    public ScheduledTask runGlobalLater(String taskName, Runnable task, long delayTicks) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        try {
+            Object foliaTask = globalRunDelayed.invoke(
+                    globalScheduler,
+                    plugin,
+                    asConsumer(new NamedTask(taskName, task)),
+                    Math.max(1L, delayTicks)
+            );
+            return track(foliaTask);
+        } catch (Throwable t) {
+            throw new IllegalStateException("Failed to schedule delayed global task: " + taskName, t);
+        }
+    }
+
+    @Override
+    public ScheduledTask runGlobalTimer(String taskName, Runnable task, long delayTicks, long periodTicks) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        try {
+            Object foliaTask = globalRunAtFixedRate.invoke(
+                    globalScheduler,
+                    plugin,
+                    asConsumer(new NamedTask(taskName, task)),
+                    Math.max(1L, delayTicks),
+                    Math.max(1L, periodTicks)
+            );
+            return track(foliaTask);
+        } catch (Throwable t) {
+            throw new IllegalStateException("Failed to schedule repeating global task: " + taskName, t);
+        }
+    }
+
+    @Override
+    public ScheduledTask runAtLocation(
+            String taskName,
+            String worldName,
+            int blockX,
+            int blockY,
+            int blockZ,
+            Runnable task
+    ) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        World world = worldName == null ? null : Bukkit.getWorld(worldName);
+        if (world == null) {
+            return CancelledTask.INSTANCE;
+        }
+        Location location = new Location(world, blockX, blockY, blockZ);
+        NamedTask named = new NamedTask(taskName, task);
+        try {
+            regionExecuteLocation.invoke(regionScheduler, plugin, location, named);
+            return CancelledTask.INSTANCE;
+        } catch (Throwable t) {
+            throw new IllegalStateException("Failed to schedule region task: " + taskName, t);
+        }
+    }
+
+    @Override
+    public ScheduledTask runForEntity(String taskName, UUID entityId, Runnable task, Runnable retired) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        Player player = resolvePlayer(entityId);
+        if (player == null) {
+            runRetired(retired);
+            return CancelledTask.INSTANCE;
+        }
+        NamedTask named = new NamedTask(taskName, wrapEntityTask(entityId, task, retired));
+        try {
+            Object entityScheduler = entityGetScheduler.invoke(player);
+            Object foliaTask = entitySchedulerRun.invoke(
+                    entityScheduler,
+                    plugin,
+                    asConsumer(named),
+                    retiredRunnable(retired)
+            );
+            if (foliaTask == null) {
+                runRetired(retired);
+                return CancelledTask.INSTANCE;
+            }
+            return track(foliaTask);
+        } catch (Throwable t) {
+            throw new IllegalStateException("Failed to schedule entity task: " + taskName, t);
+        }
+    }
+
+    @Override
+    public ScheduledTask runForEntityLater(
+            String taskName,
+            UUID entityId,
+            Runnable task,
+            Runnable retired,
+            long delayTicks
+    ) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        Player player = resolvePlayer(entityId);
+        if (player == null) {
+            runRetired(retired);
+            return CancelledTask.INSTANCE;
+        }
+        NamedTask named = new NamedTask(taskName, wrapEntityTask(entityId, task, retired));
+        try {
+            Object entityScheduler = entityGetScheduler.invoke(player);
+            Object foliaTask = entitySchedulerRunDelayed.invoke(
+                    entityScheduler,
+                    plugin,
+                    asConsumer(named),
+                    retiredRunnable(retired),
+                    Math.max(1L, delayTicks)
+            );
+            if (foliaTask == null) {
+                runRetired(retired);
+                return CancelledTask.INSTANCE;
+            }
+            return track(foliaTask);
+        } catch (Throwable t) {
+            throw new IllegalStateException("Failed to schedule delayed entity task: " + taskName, t);
+        }
+    }
+
+    @Override
+    public void executeForEntity(String taskName, UUID entityId, Runnable task, Runnable retired) {
+        if (!isAcceptingTasks()) {
+            return;
+        }
+        Player player = resolvePlayer(entityId);
+        if (player == null) {
+            runRetired(retired);
+            return;
+        }
+        NamedTask named = new NamedTask(taskName, wrapEntityTask(entityId, task, retired));
+        try {
+            if (ownsEntity(player)) {
+                named.run();
+                return;
+            }
+            Object entityScheduler = entityGetScheduler.invoke(player);
+            Boolean scheduled = (Boolean) entitySchedulerExecute.invoke(
+                    entityScheduler,
+                    plugin,
+                    named,
+                    retiredRunnable(retired),
+                    0L
+            );
+            if (Boolean.FALSE.equals(scheduled)) {
+                runRetired(retired);
+            }
+        } catch (Throwable t) {
+            throw new IllegalStateException("Failed to execute entity task: " + taskName, t);
+        }
+    }
+
+    @Override
+    public ScheduledTask runAsync(String taskName, Runnable task) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        try {
+            Object foliaTask = asyncRunNow.invoke(
+                    asyncScheduler,
+                    plugin,
+                    asConsumer(new NamedTask(taskName, task))
+            );
+            return track(foliaTask);
+        } catch (Throwable t) {
+            throw new IllegalStateException("Failed to schedule async task: " + taskName, t);
+        }
+    }
+
+    @Override
+    public ScheduledTask runAsyncLater(String taskName, Runnable task, long delay, TimeUnit unit) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        try {
+            Object foliaTask = asyncRunDelayed.invoke(
+                    asyncScheduler,
+                    plugin,
+                    asConsumer(new NamedTask(taskName, task)),
+                    Math.max(0L, delay),
+                    unit
+            );
+            return track(foliaTask);
+        } catch (Throwable t) {
+            throw new IllegalStateException("Failed to schedule delayed async task: " + taskName, t);
+        }
+    }
+
+    @Override
+    public ScheduledTask runAsyncTimer(
+            String taskName,
+            Runnable task,
+            long delay,
+            long period,
+            TimeUnit unit
+    ) {
+        if (!isAcceptingTasks()) {
+            return CancelledTask.INSTANCE;
+        }
+        try {
+            Object foliaTask = asyncRunAtFixedRate.invoke(
+                    asyncScheduler,
+                    plugin,
+                    asConsumer(new NamedTask(taskName, task)),
+                    Math.max(0L, delay),
+                    Math.max(1L, period),
+                    unit
+            );
+            return track(foliaTask);
+        } catch (Throwable t) {
+            throw new IllegalStateException("Failed to schedule repeating async task: " + taskName, t);
+        }
+    }
+
+    private Runnable wrapEntityTask(UUID entityId, Runnable task, Runnable retired) {
+        return () -> {
+            Player online = resolvePlayer(entityId);
+            if (online == null) {
+                runRetired(retired);
+                return;
+            }
+            task.run();
+        };
+    }
+
+    private Player resolvePlayer(UUID entityId) {
+        if (entityId == null) {
+            return null;
+        }
+        Player player = Bukkit.getPlayer(entityId);
+        if (player == null || !player.isOnline()) {
+            return null;
+        }
+        return player;
+    }
+
+    private boolean ownsEntity(Entity entity) {
+        if (isOwnedByCurrentRegion == null) {
+            return false;
+        }
+        try {
+            return Boolean.TRUE.equals(isOwnedByCurrentRegion.invoke(Bukkit.getServer(), entity));
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    private boolean isOwnedByGlobalRegion() {
+        // On Folia/Canvas always hop through GlobalRegionScheduler.
+        // On Paper (same API, single tick thread), running immediately on the primary thread is safe.
+        if (regionThreaded) {
+            return false;
+        }
+        return Bukkit.isPrimaryThread();
+    }
+
+    private ScheduledTask track(Object foliaTask) {
+        if (foliaTask == null) {
+            return CancelledTask.INSTANCE;
+        }
+        ReflectiveScheduledTask wrapped = new ReflectiveScheduledTask(foliaTask);
+        tracked.add(wrapped);
+        return wrapped;
+    }
+
+    private void runRetired(Runnable retired) {
+        if (retired == null) {
+            return;
+        }
+        try {
+            retired.run();
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private Runnable retiredRunnable(Runnable retired) {
+        if (retired == null) {
+            return null;
+        }
+        return () -> runRetired(retired);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Consumer asConsumer(Runnable runnable) {
+        return task -> runnable.run();
+    }
+
+    private static Method findMethod(Class<?> type, String name, Class<?>... params)
+            throws NoSuchMethodException {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                Method method = current.getDeclaredMethod(name, params);
+                method.setAccessible(true);
+                return method;
+            } catch (NoSuchMethodException ignored) {
+                try {
+                    return current.getMethod(name, params);
+                } catch (NoSuchMethodException ignoredAgain) {
+                    current = current.getSuperclass();
+                }
+            }
+        }
+        // Interfaces (Paper returns interface types from getMethod on Server)
+        for (Class<?> iface : type.getInterfaces()) {
+            try {
+                return iface.getMethod(name, params);
+            } catch (NoSuchMethodException ignored) {
+            }
+        }
+        throw new NoSuchMethodException(type.getName() + "#" + name);
+    }
+
+    private final class ReflectiveScheduledTask implements ScheduledTask {
+        private final Object handle;
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        private ReflectiveScheduledTask(Object handle) {
+            this.handle = handle;
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled.compareAndSet(false, true)) {
+                return;
+            }
+            try {
+                if (scheduledTaskCancel != null) {
+                    scheduledTaskCancel.invoke(handle);
+                } else {
+                    Method cancel = handle.getClass().getMethod("cancel");
+                    cancel.invoke(handle);
+                }
+            } catch (Throwable ignored) {
+            }
+            tracked.remove(this);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            if (cancelled.get()) {
+                return true;
+            }
+            try {
+                Method method = handle.getClass().getMethod("isCancelled");
+                Object value = method.invoke(handle);
+                return Boolean.TRUE.equals(value);
+            } catch (Throwable ignored) {
+                return cancelled.get();
+            }
+        }
+    }
+}

--- a/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/schedule/PlatformSchedulers.java
+++ b/spigot/src/main/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/schedule/PlatformSchedulers.java
@@ -1,0 +1,109 @@
+package io.github.theodoremeyer.simplevoicegeyser.spigotmc.schedule;
+
+import io.github.theodoremeyer.simplevoicegeyser.core.schedule.TaskScheduler;
+import org.bukkit.Server;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Selects a Bukkit or Folia/Paper region scheduler adapter at startup.
+ * <p>
+ * Folia/Paper/Canvas region scheduler types are accessed reflectively so the
+ * same artifact loads on classic Spigot without hard runtime linkage to
+ * Paper-only classes.
+ */
+public final class PlatformSchedulers {
+
+    private PlatformSchedulers() {}
+
+    /**
+     * Create the appropriate scheduler for the running server.
+     * @param plugin owning plugin
+     * @return scheduler adapter
+     */
+    public static TaskScheduler create(JavaPlugin plugin) {
+        Server server = plugin.getServer();
+        if (hasRegionSchedulers(server)) {
+            return new FoliaTaskScheduler(plugin);
+        }
+        return new BukkitTaskScheduler(plugin);
+    }
+
+    /**
+     * @param server Bukkit server (or test double exposing the same method names)
+     * @return true when GlobalRegionScheduler APIs are present (Paper/Folia/Canvas)
+     */
+    public static boolean hasRegionSchedulers(Object server) {
+        if (server == null) {
+            return false;
+        }
+        try {
+            // Reflect on the runtime class (CraftServer / Folia), not the compile-time
+            // Server interface from spigot-api, which may omit these methods.
+            Class<?> type = server.getClass();
+            findPublicMethod(type, "getGlobalRegionScheduler");
+            findPublicMethod(type, "getRegionScheduler");
+            findPublicMethod(type, "getAsyncScheduler");
+            return true;
+        } catch (NoSuchMethodException | NoClassDefFoundError ex) {
+            return false;
+        }
+    }
+
+    private static void findPublicMethod(Class<?> type, String name) throws NoSuchMethodException {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                current.getMethod(name);
+                return;
+            } catch (NoSuchMethodException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+        for (Class<?> iface : type.getInterfaces()) {
+            try {
+                iface.getMethod(name);
+                return;
+            } catch (NoSuchMethodException ignored) {
+            }
+        }
+        throw new NoSuchMethodException(type.getName() + "#" + name);
+    }
+
+    /**
+     * Detect Folia/Canvas-style regionized threading (not plain Paper).
+     * Safe on non-Folia servers: uses class name checks only.
+     */
+    public static boolean isRegionThreadedRuntime() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            return true;
+        } catch (ClassNotFoundException | NoClassDefFoundError ignored) {
+        }
+        try {
+            Class.forName("io.papermc.paper.threadedregions.scheduler.EntityScheduler");
+            // Paper also has these types; brand check distinguishes Folia/Canvas.
+            String name = org.bukkit.Bukkit.getServer().getName();
+            if (name != null) {
+                String lower = name.toLowerCase();
+                return lower.contains("folia") || lower.contains("canvas");
+            }
+        } catch (Throwable ignored) {
+        }
+        return isFoliaBrand();
+    }
+
+    private static boolean isFoliaBrand() {
+        try {
+            Class<?> buildInfoClass = Class.forName("io.papermc.paper.ServerBuildInfo");
+            Object buildInfo = buildInfoClass.getMethod("buildInfo").invoke(null);
+            Class<?> keyClass = Class.forName("net.kyori.adventure.key.Key");
+            Object foliaKey = keyClass.getMethod("key", String.class, String.class)
+                    .invoke(null, "papermc", "folia");
+            Object result = buildInfoClass.getMethod("isBrandCompatible", keyClass)
+                    .invoke(buildInfo, foliaKey);
+            return Boolean.TRUE.equals(result);
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+}

--- a/spigot/src/main/resources/plugin.yml
+++ b/spigot/src/main/resources/plugin.yml
@@ -8,6 +8,7 @@ website: https://theodoremeyer.github.io
 depend: [voicechat]
 softdepend: [Geyser-Spigot, floodgate]
 prefix: SVG
+folia-supported: true
 
 commands:
   svg:

--- a/spigot/src/test/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/schedule/PlatformSchedulersTest.java
+++ b/spigot/src/test/java/io/github/theodoremeyer/simplevoicegeyser/spigotmc/schedule/PlatformSchedulersTest.java
@@ -1,0 +1,41 @@
+package io.github.theodoremeyer.simplevoicegeyser.spigotmc.schedule;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PlatformSchedulersTest {
+
+    @Test
+    void detectsMissingRegionSchedulersOnClassicServerDouble() {
+        assertFalse(PlatformSchedulers.hasRegionSchedulers(new ClassicServerDouble()));
+    }
+
+    @Test
+    void detectsRegionSchedulersWhenMethodsPresent() {
+        assertTrue(PlatformSchedulers.hasRegionSchedulers(new RegionSchedulerServerDouble()));
+    }
+
+    @SuppressWarnings("unused")
+    private static final class ClassicServerDouble {
+        public String getName() {
+            return "CraftServer";
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static final class RegionSchedulerServerDouble {
+        public Object getGlobalRegionScheduler() {
+            return new Object();
+        }
+
+        public Object getRegionScheduler() {
+            return new Object();
+        }
+
+        public Object getAsyncScheduler() {
+            return new Object();
+        }
+    }
+}


### PR DESCRIPTION
## Patches

Added full Folia and Canvas 26.1.2+ scheduler support

## Key changes

* Added an internal `TaskScheduler` abstraction supporting:

  * Global tasks
  * Region/location-owned tasks
  * Entity-owned tasks with retirement handling
  * Asynchronous tasks
  * Delayed and repeating tasks
  * Cancellation and orderly shutdown

* Added runtime scheduler selection:

  * Folia/Canvas region schedulers when available
  * Classic Bukkit scheduler on Spigot/Paper
  * Direct scheduler for Fabric and unit tests

* Added `folia-supported: true` to `plugin.yml`.

* Moved player mutations, messages, and chat operations onto entity-owned schedulers.

* Removed off-thread `Player#getLocation()` access from audio processing.

* Added entity-owned yaw and permission snapshots.

* Hardened browser, websocket, player-session, audio-thread, and shutdown lifecycle handling.

* Added stable task paths such as `svg/player/chat` and `svg/player/send-message` for Folia/Canvas profiler attribution.

## Thread-safety improvements

* Browser and websocket authentication re-resolve players by UUID.
* Stale sessions cannot remove replacement sessions.
* New connections and audio work are rejected after shutdown begins.
* Shared player and connection state now handles concurrent replacement, removal, and disconnect operations safely.
* Player validity is checked before scheduled entity work executes.
* Shutdown ordering is now Jetty → audio processing → scheduler.
* Cleanup and cancellation paths are safe to call more than once.

## Name of Pull Request


## Form
<!-- Please fill out this form before opening a pull request and marking ready for review.-->
<!-- (Draft Pull requests are excluded from requirements until marked for review.)-->

<!-- If the following check boxes are not checked, this PR will most likely be rejected.  -->

- [x] I confirm that I have implemented the changes in this PR myself.  <!-- Medium rejection chance-->
- [x] I agree to transfer all rights for the contributed work to the owner of this repository. <!-- High rejection chance-->
- [ ] I confirm that I tested all changes made in this PR thoroughly.  <!-- High rejection chance.-->
- [ ] I confirm that I followed the same code style as the rest of the repository. <!-- Low rejection chance-->
- [ ] I confirm that there are no breaking protocol changes in this PR. <!-- Low rejection chance-->


### Description
<!-- Describe the changes made in this PR. -->

### Updated Dependencies
<!-- List any dependencies that were updated in this PR. (If applicable) -->

### Fixes Issues:
<!-- List any issues that were fixed in this PR. (If applicable) -->