### PR TITLE
Web UI Update (Blocky) Revision (SvgLang)

### DIFF
--- a/core/web/js/ui.js
+++ b/core/web/js/ui.js
@@ -80,9 +80,10 @@ export class SvgUI {
             const option = document.createElement("option");
 
             option.value = mic.deviceId;
+            const micIndex = micSelect.options.length + 1;
             SvgLang.setElement(option,
                 () => mic.label ||
-                    `${SvgLang.string("microphoneIndexPrefix")} ${micSelect.options.length + 1}`
+                    `${SvgLang.string("microphoneIndexPrefix")} ${micIndex}`
             );
 
             micSelect.appendChild(option);
@@ -92,9 +93,10 @@ export class SvgUI {
             const option = document.createElement("option");
 
             option.value = speaker.deviceId;
+            const speakerIndex = speakerSelect.options.length + 1;
             SvgLang.setElement(option,
                 () => speaker.label ||
-                    `${SvgLang.string("speakerIndexPrefix")} ${speakerSelect.options.length + 1}`
+                    `${SvgLang.string("speakerIndexPrefix")} ${speakerIndex}`
             );
 
             speakerSelect.appendChild(option);

--- a/core/web/js/ui.js
+++ b/core/web/js/ui.js
@@ -39,7 +39,7 @@ export class SvgUI {
         const option = document.createElement("option");
         option.disabled = true;
         option.selected = true;
-        option.textContent = label;
+        SvgLang.setElement(option, label);
 
         select.appendChild(option);
         select.disabled = true;
@@ -64,12 +64,12 @@ export class SvgUI {
 
             this.setSelectUnavailable(
                 micSelect,
-                SvgLang.string("microphoneUnavailableLabel")
+                "microphoneUnavailableLabel"
             );
 
             this.setSelectUnavailable(
                 speakerSelect,
-                SvgLang.string("speakerUnavailableLabel")
+                "speakerUnavailableLabel"
             );
 
             Logger.log(`[Audio] ${fallbackReason}`);
@@ -80,9 +80,10 @@ export class SvgUI {
             const option = document.createElement("option");
 
             option.value = mic.deviceId;
-            option.textContent =
-                mic.label ||
-                `${SvgLang.string("microphoneIndexPrefix")} ${micSelect.options.length + 1}`;
+            SvgLang.setElement(option,
+                () => mic.label ||
+                    `${SvgLang.string("microphoneIndexPrefix")} ${micSelect.options.length + 1}`
+            );
 
             micSelect.appendChild(option);
         }
@@ -91,9 +92,10 @@ export class SvgUI {
             const option = document.createElement("option");
 
             option.value = speaker.deviceId;
-            option.textContent =
-                speaker.label ||
-                `${SvgLang.string("speakerIndexPrefix")} ${speakerSelect.options.length + 1}`;
+            SvgLang.setElement(option,
+                () => speaker.label ||
+                    `${SvgLang.string("speakerIndexPrefix")} ${speakerSelect.options.length + 1}`
+            );
 
             speakerSelect.appendChild(option);
         }
@@ -101,7 +103,7 @@ export class SvgUI {
         if (microphones.length === 0) {
             this.setSelectUnavailable(
                 micSelect,
-                SvgLang.string("noMicrophoneDetectedLabel")
+                "noMicrophoneDetectedLabel"
             );
         } else {
             micSelect.disabled = false;
@@ -110,7 +112,7 @@ export class SvgUI {
         if (speakers.length === 0) {
             this.setSelectUnavailable(
                 speakerSelect,
-                SvgLang.string("noSpeakerDetectedLabel")
+                "noSpeakerDetectedLabel"
             );
         } else {
             speakerSelect.disabled = false;
@@ -242,7 +244,7 @@ export class SvgUI {
                     this.webSocketController.disconnect();
                     this.audioController.stopMic();
                     this.pttController.reset();
-                    joinButton.textContent = SvgLang.string("joinBtnUnconnectedLabel");
+                    SvgLang.setElement(joinButton, "joinBtnUnconnectedLabel");
                     return;
                 }
 
@@ -252,10 +254,12 @@ export class SvgUI {
                     async (status) => {
                         if (status.connected) {
 
-                            statusEl.textContent = `${SvgLang.string("statusConnectedAsPrefix")} ${status.username}`;
+                            SvgLang.setElement(statusEl,
+                                () => `${SvgLang.string("statusConnectedAsPrefix")} ${status.username}`
+                            );
                             statusEl.classList.remove("disconnected");
                             statusEl.classList.add("connected");
-                            joinButton.textContent = SvgLang.string("joinBtnConnectedLabel");
+                            SvgLang.setElement(joinButton, "joinBtnConnectedLabel");
                             micSelect.disabled = true;
                             speakerSelect.disabled = true;
                             const runtime = this.audioController.getAudioRuntime();
@@ -278,13 +282,13 @@ export class SvgUI {
                                 );
                             }
                         } else {
-                            statusEl.textContent = SvgLang.string("statusDisconnectedLabel");
+                            SvgLang.setElement(statusEl, "statusDisconnectedLabel");
                             statusEl.classList.remove("connected");
                             statusEl.classList.add("disconnected");
                             micSelect.disabled = false;
                             speakerSelect.disabled = false;
                             this.pttController.reset();
-                            joinButton.textContent = SvgLang.string("joinBtnUnconnectedLabel");
+                            SvgLang.setElement(joinButton, "joinBtnUnconnectedLabel");
                         }
                     }
                 );
@@ -298,9 +302,11 @@ export class SvgUI {
 
                 this.pttController.setMuted(muted);
 
-                muteBtn.textContent = muted
+                SvgLang.setElement(muteBtn,
+                    () => muted
                         ? SvgLang.string("muteBtnUnmuteLabel")
-                        : SvgLang.string("muteBtnMuteLabel");
+                        : SvgLang.string("muteBtnMuteLabel")
+                );
 
                 muteBtn.classList.toggle("muted", muted);
 

--- a/core/web/js/ui.js
+++ b/core/web/js/ui.js
@@ -80,9 +80,10 @@ export class SvgUI {
             const option = document.createElement("option");
 
             option.value = mic.deviceId;
+            const micIndex = micSelect.options.length + 1;
             SvgLang.setElement(option,
                 () => mic.label ||
-                    `${SvgLang.string("microphoneIndexPrefix")} ${micSelect.options.length + 1}`
+                    `${SvgLang.string("microphoneIndexPrefix")} ${micIndex}`
             );
 
             micSelect.appendChild(option);

--- a/core/web/js/utils/lang.js
+++ b/core/web/js/utils/lang.js
@@ -170,8 +170,10 @@ export class SvgLang {
     static #setElementText(element, content) {
         if (typeof content === "string") {
             element.textContent = SvgLang.string(content);
-        } else {
+        } else if (typeof content === "function") {
             element.textContent = content();
+        } else {
+            throw new TypeError("SvgLang.setElement content must be of type 'string | (() => string)'");
         }
     }
 
@@ -182,8 +184,8 @@ export class SvgLang {
      *
      * Use it as a replacement for `element.textContent = someText`.
      *
-     * @param element HTMLElement
-     * @param content JS Translation Key or No-Param String-Returning Factory
+     * @param {HTMLElement} element
+     * @param {string|(() => string)} content JS translation key or no-arg string factory JS Translation Key or No-Param String-Returning Factory
      *
      * @example
      * SvgLang.setElement(el, "jsTranslationLabel");
@@ -215,8 +217,12 @@ export class SvgLang {
             }
         });
 
-        SvgLang.#jsElementMap.forEach((content, element, _) => {
+        for (const [element, content] of SvgLang.#jsElementMap) {
+            if (!element.isConnected) {
+                SvgLang.#jsElementMap.delete(element);
+                continue;
+            }
             SvgLang.#setElementText(element, content);
-        });
+        }
     }
 }

--- a/core/web/js/utils/lang.js
+++ b/core/web/js/utils/lang.js
@@ -142,6 +142,8 @@ export class SvgLang {
         return SvgLang.#currentLanguage;
     }
 
+    static #jsElementMap = new Map();
+
     static detectLanguage() {
         let langCode = localStorage.getItem("preferredLanguage");
         if (langCode === null) {
@@ -165,6 +167,36 @@ export class SvgLang {
         return text;
     }
 
+    static #setElementText(element, content) {
+        if (typeof content === "string") {
+            element.textContent = SvgLang.string(content);
+        } else {
+            element.textContent = content();
+        }
+    }
+
+    /**
+     * Set an element with some textContent involving translations.
+     *
+     * It automatically recomputes the text when required.
+     *
+     * Use it as a replacement for `element.textContent = someText`.
+     *
+     * @param element HTMLElement
+     * @param content JS Translation Key or No-Param String-Returning Factory
+     *
+     * @example
+     * SvgLang.setElement(el, "jsTranslationLabel");
+     *
+     * SvgLang.setElement(el, () =>
+     *     `A factory that uses ${SvgLang.string("jsTranslationLabel")}, useful for computed strings`
+     * );
+     */
+    static setElement(element, content) {
+        SvgLang.#jsElementMap.set(element, content);
+        SvgLang.#setElementText(element, content);
+    }
+
     static changeLanguage(langCode) {
         if (!SvgLang.availableLanguages.includes(langCode)) {
             Logger.log(`Translation for country code ${langCode} unavailable... defaulting to English.`)
@@ -181,6 +213,10 @@ export class SvgLang {
             if (key in translation) {
                 element.textContent = translation[key];
             }
+        });
+
+        SvgLang.#jsElementMap.forEach((content, element, _) => {
+            SvgLang.#setElementText(element, content);
         });
     }
 }


### PR DESCRIPTION
## Form
<!-- Please fill out this form before opening a pull request and marking ready for review.-->
<!-- (Draft Pull requests are excluded from requirements until marked for review.)-->

<!-- If the following check boxes are not checked, this PR will most likely be rejected.  -->

- [x] I confirm that I have implemented the changes in this PR myself.  <!-- Medium rejection chance-->
- [x] I agree to transfer all rights for the contributed work to the owner of this repository. <!-- High rejection chance-->
- [x] I confirm that I tested all changes made in this PR thoroughly.  <!-- High rejection chance.-->
- [x] I confirm that I followed the same code style as the rest of the repository. <!-- Low rejection chance-->
- [x] I confirm that there are no breaking protocol changes in this PR. <!-- Low rejection chance-->


### Description
Fixed a problem where JS translations will not update to respect the user's new language change.

This bug caused JS translated text to be reset back to the HTML translation from `data-lang`, forcing the user to refresh the page and sign in again to regain full language support

Added a new function `SvgLang.setElement(el, content)`,  
which is meant to be used as a replacement for `el.textContent = content`
```js
SvgLang.setElement(element, content);

// Usage
SvgLang.setElement(el, "jsTranslationLabel");
    
SvgLang.setElement(el, () =>
    `A factory that uses ${SvgLang.string("jsTranslationLabel")}, useful for computed strings`
);
```

Regarding my previous PR #81, I've reviewed & tested my code. This feature was the only thing I forgot to implement. Everything I'm responsible for works.